### PR TITLE
Fix Akama fight - Correct id

### DIFF
--- a/src/game/AI/ScriptDevAI/scripts/outland/black_temple/black_temple.h
+++ b/src/game/AI/ScriptDevAI/scripts/outland/black_temple/black_temple.h
@@ -22,7 +22,7 @@ enum
     // NPC_WARLORD_NAJENTUS         = 22887,
     // NPC_SUPREMUS                 = 22898,
     NPC_SHADE_OF_AKAMA              = 22841,
-    NPC_AKAMA_SHADE                 = 22990,
+    NPC_AKAMA_SHADE                 = 23191,
     NPC_RELIQUARY_OF_SOULS          = 22856,
     NPC_ILLIDARI_COUNCIL            = 23426,
     NPC_COUNCIL_VOICE               = 23499,


### PR DESCRIPTION
The previous id is a dummy Akama(no data in db) that isn't in the instance, this results in failed script queries when it tries to update on channeler death.

Akama also has a faction that incompatible with the defenders, causing them not to attack him.
Fix: UPDATE creature_template Set Faction = 1812 WHERE Entry = 23191; 

Addresses: https://github.com/cmangos/issues/issues/1814